### PR TITLE
Add PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,18 @@
+# Maintainer: Greg Lutostanski <greg.lutostanski@mobilityhouse.com>
+pkgname=pincers
+pkgver=0.1.0
+pkgrel=1
+makedepends=('rust' 'cargo')
+arch=('i686' 'x86_64' 'armv6h' 'armv7h')
+pkgdesc="A more secure way to run scripts from the web"
+license=('MIT')
+url=https://github.com/lutostag/pincers
+
+build() {
+    return 0
+}
+
+package() {
+    cd $srcdir
+    cargo install --root="$pkgdir" --git="$source"
+}


### PR DESCRIPTION
First of all, thank you for such a great program! I use it everyday :)

I've created a PKGBUILD for easier installation in Arch Linux, since most people in Arch/Manjaro distros use AUR helpers to install packages which are not part of the official repositories.

The next step would be to upload/deploy it to AUR itself, but I'll let you do that part.